### PR TITLE
Restructure Preferences

### DIFF
--- a/PiBar.xcodeproj/project.pbxproj
+++ b/PiBar.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		449395E82471AC9D00FA0C34 /* MainMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449395E72471AC9D00FA0C34 /* MainMenuController.swift */; };
 		449395EC2471B1EB00FA0C34 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449395EB2471B1EB00FA0C34 /* PreferencesWindowController.swift */; };
 		449395EE2471C47F00FA0C34 /* PiholeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449395ED2471C47F00FA0C34 /* PiholeAPI.swift */; };
+		44B6DAF2247C70F500D364EC /* PiholeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B6DAF1247C70F500D364EC /* PiholeSettingsViewController.swift */; };
 		44FFB092247627B100DCEDEC /* PiBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FFB091247627B100DCEDEC /* PiBarManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -43,6 +44,7 @@
 		449395E72471AC9D00FA0C34 /* MainMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuController.swift; sourceTree = "<group>"; };
 		449395EB2471B1EB00FA0C34 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
 		449395ED2471C47F00FA0C34 /* PiholeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiholeAPI.swift; sourceTree = "<group>"; };
+		44B6DAF1247C70F500D364EC /* PiholeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiholeSettingsViewController.swift; sourceTree = "<group>"; };
 		44FFB091247627B100DCEDEC /* PiBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiBarManager.swift; sourceTree = "<group>"; };
 		A8CE572444810D388817476D /* Pods-PiBar.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PiBar.debug.xcconfig"; path = "Target Support Files/Pods-PiBar/Pods-PiBar.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -85,6 +87,7 @@
 				449395DB2471ABD700FA0C34 /* Preferences.storyboard */,
 				442F6F8A24721523008F1101 /* PreferencesViewController.swift */,
 				449395EB2471B1EB00FA0C34 /* PreferencesWindowController.swift */,
+				44B6DAF1247C70F500D364EC /* PiholeSettingsViewController.swift */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				442F6F89247212D2008F1101 /* Preferences.swift in Sources */,
 				442F6F872471E8DF008F1101 /* Extensions.swift in Sources */,
 				449395EC2471B1EB00FA0C34 /* PreferencesWindowController.swift in Sources */,
+				44B6DAF2247C70F500D364EC /* PiholeSettingsViewController.swift in Sources */,
 				449395EE2471C47F00FA0C34 /* PiholeAPI.swift in Sources */,
 				449395D62471ABD600FA0C34 /* AppDelegate.swift in Sources */,
 				44FFB092247627B100DCEDEC /* PiBarManager.swift in Sources */,

--- a/PiBar/Data Sources/PiBarManager.swift
+++ b/PiBar/Data Sources/PiBarManager.swift
@@ -168,7 +168,7 @@ class PiBarManager: NSObject {
                     if summary.status != "enabled" {
                         enabled = false
                     }
-                    if !pihole.api.connection.token.isEmpty {
+                    if !pihole.api.connection.token.isEmpty ||  !pihole.api.connection.passwordProtected {
                         canBeManaged = true
                     }
                 } else {

--- a/PiBar/Data Sources/PiBarManager.swift
+++ b/PiBar/Data Sources/PiBarManager.swift
@@ -26,7 +26,7 @@ class PiBarManager: NSObject {
     private let updateInterval: TimeInterval = 3
 
     override init() {
-        Log.logLevel = .off
+        Log.logLevel = .debug
         Log.useEmoji = true
 
         networkOverview = PiholeNetworkOverview(
@@ -121,7 +121,7 @@ class PiBarManager: NSObject {
         )
     }
 
-    private func createPiholes(_ connections: [PiholeConnection]) {
+    private func createPiholes(_ connections: [PiholeConnectionV2]) {
         Log.debug("Manager: Updating Connections")
 
         stopTimer()
@@ -269,7 +269,6 @@ class PiBarManager: NSObject {
     }
 
     private func canManage() -> Bool {
-        // We return true here
         for pihole in piholes.values where pihole.canBeManaged ?? false {
             return true
         }

--- a/PiBar/Data Sources/PiholeAPI.swift
+++ b/PiBar/Data Sources/PiholeAPI.swift
@@ -12,7 +12,7 @@
 import Cocoa
 
 class PiholeAPI: NSObject {
-    let connection: PiholeConnection
+    let connection: PiholeConnectionV2
 
     var identifier: String {
         return "\(connection.hostname)"
@@ -32,11 +32,11 @@ class PiholeAPI: NSObject {
     }
 
     override init() {
-        connection = PiholeConnection(hostname: "pi-hole.local", port: 80, useSSL: false, token: "")
+        connection = PiholeConnectionV2(hostname: "pi-hole.local", port: 80, useSSL: false, token: "", passwordProtected: true)
         super.init()
     }
 
-    init(connection: PiholeConnection) {
+    init(connection: PiholeConnectionV2) {
         self.connection = connection
         super.init()
     }

--- a/PiBar/Data Sources/PiholeAPI.swift
+++ b/PiBar/Data Sources/PiholeAPI.swift
@@ -54,14 +54,33 @@ class PiholeAPI: NSObject {
             builtURLString.append(contentsOf: "=\(argument)")
         }
 
+        Log.debug("Built API String: \(builtURLString)")
+
         guard let builtURL = URL(string: builtURLString) else { return completion(nil) }
 
-        do {
-            let string = try String(contentsOf: builtURL)
-            completion(string)
-        } catch {
-            completion(nil)
+        var urlRequest = URLRequest(url: builtURL)
+        urlRequest.httpMethod = "GET"
+        urlRequest.timeoutInterval = 3
+        let session = URLSession(configuration: .default)
+        let dataTask = session.dataTask(with: urlRequest) { (data, response, error) in
+            if error != nil {
+                completion(nil)
+            }
+            if let response = response as? HTTPURLResponse {
+                if 200 ..< 300 ~= response.statusCode {
+                    if let data = data, let string = String(data: data, encoding: .utf8) {
+                        completion(string)
+                    } else {
+                        completion(nil)
+                    }
+                } else {
+                    completion(nil)
+                }
+            } else {
+                completion(nil)
+            }
         }
+        dataTask.resume()
     }
 
     private func decodeJSON<T>(_ string: String) -> T? where T: Decodable {
@@ -90,28 +109,16 @@ class PiholeAPI: NSObject {
     // MARK: - Testing
 
     func testConnection(completion: @escaping (PiholeConnectionTestResult) -> Void) {
-        if connection.token.isEmpty {
-            fetchSummary { summary in
-                DispatchQueue.main.async {
-                    if summary != nil {
-                        completion(.successNoToken)
+        fetchTopItems { string in
+            DispatchQueue.main.async {
+                if let contents = string {
+                    if contents == "[]" {
+                        completion(.failureInvalidToken)
                     } else {
-                        completion(.failure)
+                        completion(.success)
                     }
-                }
-            }
-        } else {
-            fetchTopItems { string in
-                DispatchQueue.main.async {
-                    if let contents = string {
-                        if contents == "[]" {
-                            completion(.failureInvalidToken)
-                        } else {
-                            completion(.success)
-                        }
-                    } else {
-                        completion(.failure)
-                    }
+                } else {
+                    completion(.failure)
                 }
             }
         }

--- a/PiBar/Data Sources/PiholeAPI.swift
+++ b/PiBar/Data Sources/PiholeAPI.swift
@@ -32,7 +32,7 @@ class PiholeAPI: NSObject {
     }
 
     override init() {
-        connection = PiholeConnectionV2(hostname: "pi-hole.local", port: 80, useSSL: false, token: "", passwordProtected: true)
+        connection = PiholeConnectionV2(hostname: "pi.hole", port: 80, useSSL: false, token: "", passwordProtected: true, adminPanelURL: "http://pi.hole/admin/")
         super.init()
     }
 

--- a/PiBar/Data Sources/Preferences.swift
+++ b/PiBar/Data Sources/Preferences.swift
@@ -60,7 +60,8 @@ extension UserDefaults {
                         port: pihole.port,
                         useSSL: pihole.useSSL,
                         token: pihole.token,
-                        passwordProtected: true)
+                        passwordProtected: true
+                    )
                     )
                 }
                 set([], for: Preferences.Key.piholes)

--- a/PiBar/Data Sources/Preferences.swift
+++ b/PiBar/Data Sources/Preferences.swift
@@ -60,9 +60,12 @@ extension UserDefaults {
                         port: pihole.port,
                         useSSL: pihole.useSSL,
                         token: pihole.token,
-                        passwordProtected: true
-                    )
-                    )
+                        passwordProtected: true,
+                        adminPanelURL: PiholeConnectionV2.generateAdminPanelURL(
+                            hostname: pihole.hostname,
+                            port: pihole.port,
+                            useSSL: pihole.useSSL)
+                    ))
                 }
                 set([], for: Preferences.Key.piholes)
                 let encodedArray = piholesV2.map { $0.encode()! }

--- a/PiBar/Data Sources/Structs.swift
+++ b/PiBar/Data Sources/Structs.swift
@@ -13,19 +13,51 @@ import Foundation
 
 // MARK: - Pi-hole Connections
 
-struct PiholeConnection: Codable {
+struct PiholeConnectionV1: Codable {
     let hostname: String
     let port: Int
     let useSSL: Bool
     let token: String
 }
 
-extension PiholeConnection {
+extension PiholeConnectionV1 {
     init?(data: Data) {
         let jsonDecoder = JSONDecoder()
-        if let object = try? jsonDecoder.decode(PiholeConnection.self, from: data) {
+        do {
+            let object = try jsonDecoder.decode(PiholeConnectionV1.self, from: data)
             self = object
+        } catch {
+            Log.debug("Couldn't decode connection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func encode() -> Data? {
+        let jsonEncoder = JSONEncoder()
+        if let data = try? jsonEncoder.encode(self) {
+            return data
         } else {
+            return nil
+        }
+    }
+}
+
+struct PiholeConnectionV2: Codable {
+    let hostname: String
+    let port: Int
+    let useSSL: Bool
+    let token: String
+    let passwordProtected: Bool
+}
+
+extension PiholeConnectionV2 {
+    init?(data: Data) {
+        let jsonDecoder = JSONDecoder()
+        do {
+            let object = try jsonDecoder.decode(PiholeConnectionV2.self, from: data)
+            self = object
+        } catch {
+            Log.debug("Couldn't decode connection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/PiBar/Data Sources/Structs.swift
+++ b/PiBar/Data Sources/Structs.swift
@@ -13,6 +13,7 @@ import Foundation
 
 // MARK: - Pi-hole Connections
 
+// PiBar v1.0 format
 struct PiholeConnectionV1: Codable {
     let hostname: String
     let port: Int
@@ -42,6 +43,7 @@ extension PiholeConnectionV1 {
     }
 }
 
+// PiBar v1.1 format
 struct PiholeConnectionV2: Codable {
     let hostname: String
     let port: Int

--- a/PiBar/Data Sources/Structs.swift
+++ b/PiBar/Data Sources/Structs.swift
@@ -76,7 +76,6 @@ extension PiholeConnectionV2 {
 
 enum PiholeConnectionTestResult {
     case success
-    case successNoToken
     case failure
     case failureInvalidToken
 }

--- a/PiBar/Data Sources/Structs.swift
+++ b/PiBar/Data Sources/Structs.swift
@@ -50,6 +50,7 @@ struct PiholeConnectionV2: Codable {
     let useSSL: Bool
     let token: String
     let passwordProtected: Bool
+    let adminPanelURL: String
 }
 
 extension PiholeConnectionV2 {
@@ -71,6 +72,11 @@ extension PiholeConnectionV2 {
         } else {
             return nil
         }
+    }
+
+    static func generateAdminPanelURL(hostname: String, port: Int, useSSL: Bool) -> String {
+        let prefix: String = useSSL ? "https" : "http"
+        return "\(prefix)://\(hostname):\(port)/admin/"
     }
 }
 

--- a/PiBar/Preferences/Base.lproj/Preferences.storyboard
+++ b/PiBar/Preferences/Base.lproj/Preferences.storyboard
@@ -470,8 +470,8 @@ of Pi-hole LLC.</string>
         <scene sceneID="ayz-je-3b6">
             <objects>
                 <viewController storyboardIdentifier="piHoleDialog" id="JhG-OK-RWV" customClass="PiholeSettingsViewController" customModule="PiBar" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="VTg-m3-cFh">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="244"/>
+                    <view key="view" misplaced="YES" id="VTg-m3-cFh">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="285"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vRR-BU-YIk">
@@ -495,21 +495,24 @@ of Pi-hole LLC.</string>
                                 </connections>
                             </button>
                             <box title="Pi-hole Settings" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="3K7-bD-5VH">
-                                <rect key="frame" x="17" y="57" width="416" height="149"/>
+                                <rect key="frame" x="17" y="57" width="416" height="190"/>
                                 <view key="contentView" id="xIe-VM-MBv">
-                                    <rect key="frame" x="3" y="3" width="410" height="143"/>
+                                    <rect key="frame" x="3" y="3" width="410" height="184"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DfX-5W-cje">
-                                            <rect key="frame" x="90" y="102" width="125" height="21"/>
+                                            <rect key="frame" x="96" y="143" width="119" height="21"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="pi.hole" drawsBackground="YES" id="OnA-u0-rmY">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
+                                            <connections>
+                                                <action selector="textFieldDidChangeAction:" target="JhG-OK-RWV" id="BpX-6c-kNL"/>
+                                            </connections>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="i4e-zs-pkU">
-                                            <rect key="frame" x="257" y="102" width="48" height="21"/>
+                                            <rect key="frame" x="257" y="143" width="48" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="48" id="rt7-vm-50T"/>
                                             </constraints>
@@ -518,9 +521,12 @@ of Pi-hole LLC.</string>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
+                                            <connections>
+                                                <action selector="textFieldDidChangeAction:" target="JhG-OK-RWV" id="mWk-HY-sxy"/>
+                                            </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MAW-Ao-XAm">
-                                            <rect key="frame" x="18" y="105" width="66" height="16"/>
+                                            <rect key="frame" x="18" y="146" width="72" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Hostname" id="gtZ-N9-HyG">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -528,7 +534,7 @@ of Pi-hole LLC.</string>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ut9-zN-gOe">
-                                            <rect key="frame" x="221" y="105" width="30" height="16"/>
+                                            <rect key="frame" x="221" y="146" width="30" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Port" id="1id-2a-G2U">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -536,7 +542,7 @@ of Pi-hole LLC.</string>
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ey9-va-KwP">
-                                            <rect key="frame" x="319" y="104" width="73" height="18"/>
+                                            <rect key="frame" x="319" y="145" width="73" height="18"/>
                                             <buttonCell key="cell" type="check" title="Use SSL" bezelStyle="regularSquare" imagePosition="left" inset="2" id="B8q-U5-9nB">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -546,7 +552,7 @@ of Pi-hole LLC.</string>
                                             </connections>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gNv-Mk-yT2">
-                                            <rect key="frame" x="18" y="64" width="66" height="16"/>
+                                            <rect key="frame" x="18" y="105" width="64" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="API Token" id="i0I-aw-SzO">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -554,12 +560,15 @@ of Pi-hole LLC.</string>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bHH-DP-Aad">
-                                            <rect key="frame" x="90" y="61" width="300" height="21"/>
+                                            <rect key="frame" x="96" y="102" width="294" height="21"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="No password on your Pi-hole? Leave this blank." drawsBackground="YES" id="Dz6-14-hXD">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
+                                            <connections>
+                                                <action selector="textFieldDidChangeAction:" target="JhG-OK-RWV" id="UFk-7F-3lK"/>
+                                            </connections>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8yS-Xd-FIv">
                                             <rect key="frame" x="257" y="13" width="139" height="32"/>
@@ -579,26 +588,51 @@ of Pi-hole LLC.</string>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pmr-bw-vTK">
+                                            <rect key="frame" x="96" y="61" width="294" height="21"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="zmA-hX-b4k">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <action selector="textFieldDidChangeAction:" target="JhG-OK-RWV" id="kCV-pe-4mU"/>
+                                            </connections>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PT9-i1-RMA">
+                                            <rect key="frame" x="18" y="64" width="72" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Admin URL" id="sRK-zn-AHQ">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="DfX-5W-cje" firstAttribute="leading" secondItem="MAW-Ao-XAm" secondAttribute="trailing" constant="8" id="1Ie-pR-YQm"/>
                                         <constraint firstItem="ut9-zN-gOe" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="22" id="1M8-mX-jeT"/>
+                                        <constraint firstItem="Pmr-bw-vTK" firstAttribute="leading" secondItem="PT9-i1-RMA" secondAttribute="trailing" constant="8" id="2KR-LW-eHL"/>
                                         <constraint firstItem="8yS-Xd-FIv" firstAttribute="leading" secondItem="3yj-eZ-X0Q" secondAttribute="trailing" constant="16" id="44O-MJ-Xpd"/>
                                         <constraint firstItem="DfX-5W-cje" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="20" id="8ck-rO-YT5"/>
+                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="Pmr-bw-vTK" secondAttribute="leading" id="BwU-gs-dMJ"/>
                                         <constraint firstItem="Ey9-va-KwP" firstAttribute="leading" secondItem="i4e-zs-pkU" secondAttribute="trailing" constant="16" id="Gfc-PQ-qLm"/>
                                         <constraint firstItem="gNv-Mk-yT2" firstAttribute="top" secondItem="MAW-Ao-XAm" secondAttribute="bottom" constant="25" id="I6S-n6-VhR"/>
                                         <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="DfX-5W-cje" secondAttribute="leading" id="KgH-9Q-keL"/>
-                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="gNv-Mk-yT2" secondAttribute="trailing" constant="8" id="NHv-UB-iga"/>
+                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="gNv-Mk-yT2" secondAttribute="trailing" constant="16" id="NHv-UB-iga"/>
                                         <constraint firstAttribute="trailing" secondItem="Ey9-va-KwP" secondAttribute="trailing" constant="20" id="OCA-VW-hOb"/>
                                         <constraint firstAttribute="trailing" secondItem="bHH-DP-Aad" secondAttribute="trailing" constant="20" id="OHo-Iw-mnv"/>
-                                        <constraint firstItem="8yS-Xd-FIv" firstAttribute="top" secondItem="bHH-DP-Aad" secondAttribute="bottom" constant="20" id="VCk-x3-DRG"/>
+                                        <constraint firstAttribute="trailing" secondItem="Pmr-bw-vTK" secondAttribute="trailing" constant="20" id="PgW-eh-8qs"/>
+                                        <constraint firstItem="PT9-i1-RMA" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="Puy-oB-Koy"/>
+                                        <constraint firstAttribute="bottom" secondItem="3yj-eZ-X0Q" secondAttribute="bottom" constant="23" id="ZKr-sN-oVJ"/>
+                                        <constraint firstItem="PT9-i1-RMA" firstAttribute="top" secondItem="gNv-Mk-yT2" secondAttribute="bottom" constant="25" id="bcf-0y-X8j"/>
                                         <constraint firstItem="i4e-zs-pkU" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="20" id="dk6-se-Tvm"/>
                                         <constraint firstItem="Ey9-va-KwP" firstAttribute="centerY" secondItem="i4e-zs-pkU" secondAttribute="centerY" id="dn5-n2-9pM"/>
-                                        <constraint firstItem="3yj-eZ-X0Q" firstAttribute="top" secondItem="bHH-DP-Aad" secondAttribute="bottom" constant="22" id="fH4-EK-Oef"/>
+                                        <constraint firstItem="8yS-Xd-FIv" firstAttribute="top" secondItem="Pmr-bw-vTK" secondAttribute="bottom" constant="20" id="fIV-Ks-yk9"/>
                                         <constraint firstItem="3yj-eZ-X0Q" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="jGA-OR-lsd"/>
                                         <constraint firstItem="bHH-DP-Aad" firstAttribute="top" secondItem="DfX-5W-cje" secondAttribute="bottom" constant="20" id="l6z-e7-L62"/>
                                         <constraint firstAttribute="trailing" secondItem="8yS-Xd-FIv" secondAttribute="trailing" constant="20" id="lhc-aT-bO8"/>
                                         <constraint firstItem="MAW-Ao-XAm" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="oGQ-a5-dsw"/>
+                                        <constraint firstItem="Pmr-bw-vTK" firstAttribute="top" secondItem="bHH-DP-Aad" secondAttribute="bottom" constant="20" id="pbR-IS-CCL"/>
                                         <constraint firstItem="gNv-Mk-yT2" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="roe-fp-efQ"/>
                                         <constraint firstItem="i4e-zs-pkU" firstAttribute="leading" secondItem="ut9-zN-gOe" secondAttribute="trailing" constant="8" id="vTD-sS-2r2"/>
                                         <constraint firstAttribute="bottom" secondItem="8yS-Xd-FIv" secondAttribute="bottom" constant="20" id="wd5-G0-YLT"/>
@@ -608,7 +642,7 @@ of Pi-hole LLC.</string>
                                 </view>
                             </box>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dnY-PR-vdq">
-                                <rect key="frame" x="18" y="212" width="414" height="16"/>
+                                <rect key="frame" x="18" y="253" width="414" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Pi-hole" id="hHW-QN-ohW">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -632,6 +666,7 @@ of Pi-hole LLC.</string>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="adminURLTextField" destination="Pmr-bw-vTK" id="G0v-yt-OGW"/>
                         <outlet property="apiTokenTextField" destination="bHH-DP-Aad" id="gBu-T5-UwO"/>
                         <outlet property="closeButton" destination="vRR-BU-YIk" id="buO-2f-uD1"/>
                         <outlet property="hostnameTextField" destination="DfX-5W-cje" id="KIl-2F-AeS"/>
@@ -644,7 +679,7 @@ of Pi-hole LLC.</string>
                 </viewController>
                 <customObject id="IJx-K2-eHd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="546" y="268"/>
+            <point key="canvasLocation" x="546" y="301.5"/>
         </scene>
     </scenes>
     <resources>

--- a/PiBar/Preferences/Base.lproj/Preferences.storyboard
+++ b/PiBar/Preferences/Base.lproj/Preferences.storyboard
@@ -573,7 +573,7 @@ of Pi-hole LLC.</string>
                                         </button>
                                         <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3yj-eZ-X0Q">
                                             <rect key="frame" x="18" y="23" width="231" height="16"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" id="qJD-6U-lOR">
+                                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" id="qJD-6U-lOR">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -638,6 +638,7 @@ of Pi-hole LLC.</string>
                         <outlet property="portTextField" destination="i4e-zs-pkU" id="crJ-yc-pNH"/>
                         <outlet property="saveAndCloseButton" destination="vfb-vc-iXD" id="dB9-fJ-Qls"/>
                         <outlet property="testConnectionButton" destination="8yS-Xd-FIv" id="3qZ-7N-jrE"/>
+                        <outlet property="testConnectionLabel" destination="3yj-eZ-X0Q" id="hCe-oh-1Th"/>
                         <outlet property="useSSLCheckbox" destination="Ey9-va-KwP" id="gdT-ZG-lrd"/>
                     </connections>
                 </viewController>

--- a/PiBar/Preferences/Base.lproj/Preferences.storyboard
+++ b/PiBar/Preferences/Base.lproj/Preferences.storyboard
@@ -32,11 +32,11 @@
             <objects>
                 <viewController id="GTm-9k-36S" customClass="PreferencesViewController" customModule="PiBar" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="77P-BY-lJe">
-                        <rect key="frame" x="0.0" y="0.0" width="936" height="296"/>
+                        <rect key="frame" x="0.0" y="0.0" width="779" height="296"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iau-X6-RVt">
-                                <rect key="frame" x="708" y="264" width="210" height="16"/>
+                                <rect key="frame" x="553" y="264" width="208" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Preferences" id="KWY-Db-no8">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -44,13 +44,13 @@
                                 </textFieldCell>
                             </textField>
                             <box borderType="line" title="About" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="kjd-Se-RaQ">
-                                <rect key="frame" x="707" y="16" width="212" height="242"/>
+                                <rect key="frame" x="552" y="16" width="210" height="242"/>
                                 <view key="contentView" id="lOO-sf-eYN">
-                                    <rect key="frame" x="3" y="3" width="206" height="236"/>
+                                    <rect key="frame" x="3" y="3" width="204" height="236"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="u9t-W8-YCX">
-                                            <rect key="frame" x="18" y="206" width="170" height="16"/>
+                                            <rect key="frame" x="18" y="206" width="168" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Menu Bar Stats" id="sk4-gL-hKh">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -58,7 +58,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pTP-wb-bab">
-                                            <rect key="frame" x="18" y="66" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="66" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Verbose Labels" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="5hK-vU-hfH">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -68,7 +68,7 @@
                                             </buttonCell>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fXy-Gb-chu">
-                                            <rect key="frame" x="18" y="138" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="138" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Percentage Blocked" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8HH-3L-FeK">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -78,7 +78,7 @@
                                             </buttonCell>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rAy-oa-e4o">
-                                            <rect key="frame" x="18" y="182" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="182" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Total Queries Today" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="42R-my-5Tv">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -88,7 +88,7 @@
                                             </buttonCell>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fhh-w3-SVx">
-                                            <rect key="frame" x="18" y="112" width="170" height="16"/>
+                                            <rect key="frame" x="18" y="112" width="168" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Menu Bar Labels" id="l9j-oo-af3">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -96,7 +96,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pm7-2a-Lcf">
-                                            <rect key="frame" x="18" y="40" width="170" height="16"/>
+                                            <rect key="frame" x="18" y="40" width="168" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Other" id="fvi-02-uIF">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -104,7 +104,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XD6-Xz-dyn">
-                                            <rect key="frame" x="18" y="88" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="88" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show Labels" bezelStyle="regularSquare" imagePosition="left" inset="2" id="KhV-ji-e9I">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -114,7 +114,7 @@
                                             </buttonCell>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MiM-8y-LcW">
-                                            <rect key="frame" x="18" y="160" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="160" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Blocked Queries Today" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Vkd-pK-s3u">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -124,7 +124,7 @@
                                             </buttonCell>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xv5-Li-uDo">
-                                            <rect key="frame" x="18" y="18" width="170" height="18"/>
+                                            <rect key="frame" x="18" y="18" width="168" height="18"/>
                                             <buttonCell key="cell" type="check" title="Enable ⌘⌥⇧P Shortcut" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L41-Mt-pHb">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -167,25 +167,25 @@
                                 </view>
                             </box>
                             <box title="Pi-holes" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="rf3-sM-sEw">
-                                <rect key="frame" x="267" y="16" width="426" height="242"/>
+                                <rect key="frame" x="267" y="16" width="271" height="242"/>
                                 <view key="contentView" id="U8L-6W-MRA">
-                                    <rect key="frame" x="3" y="3" width="420" height="236"/>
+                                    <rect key="frame" x="3" y="3" width="265" height="236"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="7by-VC-c7V">
-                                            <rect key="frame" x="20" y="53" width="175" height="163"/>
+                                            <rect key="frame" x="20" y="53" width="225" height="163"/>
                                             <clipView key="contentView" id="7U0-rZ-cjX">
-                                                <rect key="frame" x="1" y="0.0" width="173" height="162"/>
+                                                <rect key="frame" x="1" y="0.0" width="223" height="162"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="lI7-le-hIe" viewBased="YES" id="ILp-pd-N6u">
-                                                        <rect key="frame" x="0.0" y="0.0" width="176" height="137"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="223" height="137"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
-                                                            <tableColumn width="102" minWidth="40" maxWidth="1000" id="6Az-AI-g5G">
+                                                            <tableColumn width="159" minWidth="40" maxWidth="1000" id="6Az-AI-g5G">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Hostname">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -198,11 +198,11 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="hostnameCell" id="TXu-ee-LVQ">
-                                                                        <rect key="frame" x="1" y="1" width="102" height="17"/>
+                                                                        <rect key="frame" x="1" y="1" width="159" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="9dL-In-WC2">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="102" height="17"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="159" height="17"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="17" id="fs9-rj-VQ2"/>
                                                                                 </constraints>
@@ -224,7 +224,7 @@
                                                                     </tableCellView>
                                                                 </prototypeCellViews>
                                                             </tableColumn>
-                                                            <tableColumn width="68" minWidth="10" maxWidth="3.4028234663852886e+38" id="bXZ-MT-Are">
+                                                            <tableColumn width="58" minWidth="10" maxWidth="3.4028234663852886e+38" id="bXZ-MT-Are">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Port">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -237,11 +237,11 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="portCell" id="dAY-Du-JhP">
-                                                                        <rect key="frame" x="106" y="1" width="68" height="17"/>
+                                                                        <rect key="frame" x="163" y="1" width="58" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="RbF-1c-Sbq" userLabel="Port">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="68" height="17"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="58" height="17"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="17" id="a6a-Xt-gEO"/>
                                                                                 </constraints>
@@ -273,7 +273,7 @@
                                             </clipView>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="163" id="XQN-3C-Y3k"/>
-                                                <constraint firstAttribute="width" constant="175" id="iom-a0-5Mm"/>
+                                                <constraint firstAttribute="width" constant="225" id="jdC-01-paz"/>
                                             </constraints>
                                             <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Amq-0r-Eqc">
                                                 <rect key="frame" x="-100" y="-100" width="173" height="16"/>
@@ -284,108 +284,10 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <tableHeaderView key="headerView" id="lI7-le-hIe">
-                                                <rect key="frame" x="0.0" y="0.0" width="176" height="25"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="223" height="25"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tFg-7b-Rry">
-                                            <rect key="frame" x="112" y="13" width="89" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6ay-sO-FV9">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="removeButtonAction:" target="GTm-9k-36S" id="Gow-VR-PAc"/>
-                                            </connections>
-                                        </button>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pZ9-KE-hU0">
-                                            <rect key="frame" x="213" y="137" width="68" height="17"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" title="API Token" id="Mop-d6-Z0o">
-                                                <font key="font" metaFont="menu" size="14"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1AN-M9-Xrk">
-                                            <rect key="frame" x="215" y="108" width="127" height="21"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="None" drawsBackground="YES" usesSingleLineMode="YES" id="qfp-Bb-eCz">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                            <connections>
-                                                <action selector="textFieldChangedAction:" target="GTm-9k-36S" id="lvC-Ls-pXK"/>
-                                            </connections>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xmg-NF-pTK">
-                                            <rect key="frame" x="213" y="199" width="95" height="17"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Hostname / IP" id="7QX-ZI-Nwc">
-                                                <font key="font" metaFont="menu" size="14"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8se-uT-fOl">
-                                            <rect key="frame" x="215" y="170" width="127" height="21"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="pi-hole.local" drawsBackground="YES" id="vB3-Lb-dsD">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                            <connections>
-                                                <action selector="textFieldChangedAction:" target="GTm-9k-36S" id="JcT-y1-gRr"/>
-                                            </connections>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eZE-EZ-Avs">
-                                            <rect key="frame" x="348" y="199" width="32" height="17"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Port" id="P07-M9-KNf">
-                                                <font key="font" metaFont="menu" size="14"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="amu-Zp-vc1">
-                                            <rect key="frame" x="350" y="170" width="50" height="21"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="rLc-8K-P1W"/>
-                                            </constraints>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" placeholderString="80" drawsBackground="YES" id="Fq0-Tt-1Px">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                            <connections>
-                                                <action selector="textFieldChangedAction:" target="GTm-9k-36S" id="0K5-PK-Fu6"/>
-                                            </connections>
-                                        </textField>
-                                        <button horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hMD-ck-yTN">
-                                            <rect key="frame" x="209" y="60" width="66" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Test" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wPX-Og-qIz">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="testButtonAction:" target="GTm-9k-36S" id="e75-Zu-HzR"/>
-                                            </connections>
-                                        </button>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pEj-fh-i1X">
-                                            <rect key="frame" x="277" y="70" width="125" height="16"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" id="Lsp-L6-mqs">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="56y-tY-tLW">
-                                            <rect key="frame" x="350" y="110" width="52" height="18"/>
-                                            <buttonCell key="cell" type="check" title="SSL" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="eqK-CG-AAb">
-                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="useSSLCheckboxAction:" target="GTm-9k-36S" id="Nlc-Hb-XdN"/>
-                                            </connections>
-                                        </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZHY-Hb-6iQ">
                                             <rect key="frame" x="14" y="13" width="65" height="32"/>
                                             <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="F7H-c0-5xe">
@@ -396,66 +298,40 @@
                                                 <action selector="addButtonActiom:" target="GTm-9k-36S" id="Atu-qe-gHB"/>
                                             </connections>
                                         </button>
-                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="urc-nj-3bN">
-                                            <rect key="frame" x="215" y="28" width="111" height="5"/>
-                                        </box>
-                                        <button horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-H4-SfT">
-                                            <rect key="frame" x="336" y="13" width="70" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iCh-9j-CfH">
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tFg-7b-Rry">
+                                            <rect key="frame" x="162" y="13" width="89" height="32"/>
+                                            <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6ay-sO-FV9">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
-                                                <action selector="saveButtonAction:" target="GTm-9k-36S" id="hMt-xO-6G3"/>
+                                                <action selector="removeButtonAction:" target="GTm-9k-36S" id="Gow-VR-PAc"/>
                                             </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UaV-nP-7Dw">
+                                            <rect key="frame" x="89" y="13" width="64" height="32"/>
+                                            <buttonCell key="cell" type="push" title="Edit" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bLq-nZ-MXL">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="tFg-7b-Rry" firstAttribute="leading" secondItem="ZHY-Hb-6iQ" secondAttribute="trailing" constant="45" id="0Jc-ff-JkS"/>
-                                        <constraint firstItem="pEj-fh-i1X" firstAttribute="leading" secondItem="hMD-ck-yTN" secondAttribute="trailing" constant="10" id="1Sd-FJ-IxM"/>
-                                        <constraint firstItem="1AN-M9-Xrk" firstAttribute="width" secondItem="8se-uT-fOl" secondAttribute="width" id="2gn-dI-BPi"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eZE-EZ-Avs" secondAttribute="trailing" constant="20" id="3gM-Is-GpM"/>
-                                        <constraint firstItem="pEj-fh-i1X" firstAttribute="centerY" secondItem="hMD-ck-yTN" secondAttribute="centerY" id="4II-cU-j7x"/>
-                                        <constraint firstItem="eZE-EZ-Avs" firstAttribute="leading" secondItem="amu-Zp-vc1" secondAttribute="leading" id="4Mg-Lk-nNC"/>
-                                        <constraint firstItem="hMD-ck-yTN" firstAttribute="top" secondItem="1AN-M9-Xrk" secondAttribute="bottom" constant="20" id="4yE-fX-oAQ"/>
-                                        <constraint firstItem="amu-Zp-vc1" firstAttribute="top" secondItem="eZE-EZ-Avs" secondAttribute="bottom" constant="8" id="68y-MO-6vE"/>
-                                        <constraint firstItem="1AN-M9-Xrk" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="9aE-e5-jxh"/>
                                         <constraint firstItem="7by-VC-c7V" firstAttribute="top" secondItem="U8L-6W-MRA" secondAttribute="top" constant="20" id="Dod-9a-MfV"/>
                                         <constraint firstAttribute="bottom" secondItem="ZHY-Hb-6iQ" secondAttribute="bottom" constant="20" id="Ewh-vQ-tZf"/>
-                                        <constraint firstItem="pZ9-KE-hU0" firstAttribute="top" secondItem="8se-uT-fOl" secondAttribute="bottom" constant="16" id="FeY-W4-hx8"/>
-                                        <constraint firstAttribute="trailing" secondItem="amu-Zp-vc1" secondAttribute="trailing" constant="20" id="HTY-tv-Vbn"/>
-                                        <constraint firstItem="hMD-ck-yTN" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="Jyq-CU-e8w"/>
                                         <constraint firstItem="7by-VC-c7V" firstAttribute="leading" secondItem="U8L-6W-MRA" secondAttribute="leading" constant="20" id="OWN-SX-plv"/>
-                                        <constraint firstItem="xmg-NF-pTK" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="Ovr-iq-iub"/>
-                                        <constraint firstItem="56y-tY-tLW" firstAttribute="leading" secondItem="1AN-M9-Xrk" secondAttribute="trailing" constant="10" id="PBR-Et-nDP"/>
-                                        <constraint firstAttribute="bottom" secondItem="urc-nj-3bN" secondAttribute="bottom" constant="30" id="T0i-8Y-jS5"/>
-                                        <constraint firstAttribute="trailing" secondItem="HO3-H4-SfT" secondAttribute="trailing" constant="20" id="T73-S8-oBF"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="pZ9-KE-hU0" secondAttribute="trailing" constant="20" symbolic="YES" id="UAK-jP-vB7"/>
-                                        <constraint firstItem="pZ9-KE-hU0" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="XIA-jn-1sK"/>
-                                        <constraint firstItem="8se-uT-fOl" firstAttribute="top" secondItem="xmg-NF-pTK" secondAttribute="bottom" constant="8" id="Z8K-VJ-jnQ"/>
-                                        <constraint firstItem="eZE-EZ-Avs" firstAttribute="top" secondItem="U8L-6W-MRA" secondAttribute="top" constant="20" id="ZGG-hU-2hl"/>
                                         <constraint firstItem="ZHY-Hb-6iQ" firstAttribute="leading" secondItem="U8L-6W-MRA" secondAttribute="leading" constant="20" id="aH7-zX-tw4"/>
                                         <constraint firstItem="ZHY-Hb-6iQ" firstAttribute="top" secondItem="7by-VC-c7V" secondAttribute="bottom" constant="12" id="bXu-OJ-uiQ"/>
-                                        <constraint firstAttribute="bottom" secondItem="HO3-H4-SfT" secondAttribute="bottom" constant="20" id="dJH-30-YNJ"/>
+                                        <constraint firstItem="tFg-7b-Rry" firstAttribute="leading" secondItem="UaV-nP-7Dw" secondAttribute="trailing" constant="21.5" id="cDG-kx-Yx2"/>
                                         <constraint firstAttribute="bottom" secondItem="tFg-7b-Rry" secondAttribute="bottom" constant="20" id="eTR-SP-erx"/>
-                                        <constraint firstItem="amu-Zp-vc1" firstAttribute="leading" secondItem="8se-uT-fOl" secondAttribute="trailing" constant="8" id="f4h-o1-0mw"/>
-                                        <constraint firstItem="8se-uT-fOl" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="gF7-9R-jfB"/>
-                                        <constraint firstAttribute="trailing" secondItem="pEj-fh-i1X" secondAttribute="trailing" constant="20" id="iiL-8t-5la"/>
-                                        <constraint firstItem="eZE-EZ-Avs" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xmg-NF-pTK" secondAttribute="trailing" constant="8" id="iqJ-Ku-dXY"/>
+                                        <constraint firstAttribute="trailing" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="eky-U5-oIe"/>
+                                        <constraint firstItem="UaV-nP-7Dw" firstAttribute="top" secondItem="7by-VC-c7V" secondAttribute="bottom" constant="12" id="g6u-xX-kcj"/>
                                         <constraint firstItem="7by-VC-c7V" firstAttribute="top" secondItem="U8L-6W-MRA" secondAttribute="top" constant="20" id="oKt-lm-2Rj"/>
-                                        <constraint firstItem="1AN-M9-Xrk" firstAttribute="top" secondItem="pZ9-KE-hU0" secondAttribute="bottom" constant="8" id="oUw-f3-NIm"/>
                                         <constraint firstItem="tFg-7b-Rry" firstAttribute="trailing" secondItem="7by-VC-c7V" secondAttribute="trailing" id="pgR-6R-rzL"/>
-                                        <constraint firstItem="HO3-H4-SfT" firstAttribute="leading" secondItem="urc-nj-3bN" secondAttribute="trailing" constant="16" id="sAE-7W-pz8"/>
+                                        <constraint firstItem="UaV-nP-7Dw" firstAttribute="leading" secondItem="ZHY-Hb-6iQ" secondAttribute="trailing" constant="21.5" id="roi-7g-kjO"/>
                                         <constraint firstItem="tFg-7b-Rry" firstAttribute="top" secondItem="7by-VC-c7V" secondAttribute="bottom" constant="12" id="seE-a9-geX"/>
-                                        <constraint firstItem="urc-nj-3bN" firstAttribute="leading" secondItem="7by-VC-c7V" secondAttribute="trailing" constant="20" id="tuO-IL-a61"/>
-                                        <constraint firstItem="56y-tY-tLW" firstAttribute="centerY" secondItem="1AN-M9-Xrk" secondAttribute="centerY" id="u7h-0y-p6m"/>
-                                        <constraint firstAttribute="trailing" secondItem="56y-tY-tLW" secondAttribute="trailing" constant="20" id="vyP-m3-2LM"/>
-                                        <constraint firstItem="xmg-NF-pTK" firstAttribute="top" secondItem="U8L-6W-MRA" secondAttribute="top" constant="20" id="yYK-be-NtA"/>
                                     </constraints>
                                 </view>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="420" id="e0A-tb-jPy"/>
-                                </constraints>
                                 <font key="titleFont" size="14" name="HelveticaNeue"/>
                             </box>
                             <box title="About" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="JNj-dj-3s6">
@@ -535,7 +411,7 @@ of Pi-hole LLC.</string>
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="J44-eX-Cmj">
-                                <rect key="frame" x="268" y="264" width="424" height="16"/>
+                                <rect key="frame" x="268" y="264" width="269" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Pi-holes" id="1au-rN-a6J">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -567,20 +443,13 @@ of Pi-hole LLC.</string>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="hostnameTextField" destination="8se-uT-fOl" id="FaL-mB-I1M"/>
-                        <outlet property="portTextField" destination="amu-Zp-vc1" id="9Pj-Wx-PdH"/>
                         <outlet property="removeButton" destination="tFg-7b-Rry" id="Hnp-f3-vw3"/>
-                        <outlet property="saveButton" destination="HO3-H4-SfT" id="gJm-kW-JuN"/>
                         <outlet property="shortcutEnabledCheckbox" destination="xv5-Li-uDo" id="2X1-v2-Zg4"/>
                         <outlet property="showBlockedCheckbox" destination="MiM-8y-LcW" id="BLs-6A-5qO"/>
                         <outlet property="showLabelsCheckbox" destination="XD6-Xz-dyn" id="VFz-Wn-r3f"/>
                         <outlet property="showPercentageCheckbox" destination="fXy-Gb-chu" id="tMM-eQ-KHq"/>
                         <outlet property="showQueriesCheckbox" destination="rAy-oa-e4o" id="Xha-ka-b7X"/>
                         <outlet property="tableView" destination="ILp-pd-N6u" id="iM3-Y0-JFG"/>
-                        <outlet property="testButton" destination="hMD-ck-yTN" id="1wf-La-q2M"/>
-                        <outlet property="testLabel" destination="pEj-fh-i1X" id="Bvp-dn-7td"/>
-                        <outlet property="tokenTextField" destination="1AN-M9-Xrk" id="pwe-7T-xxh"/>
-                        <outlet property="useSSLCheckbox" destination="56y-tY-tLW" id="fOA-YF-gLG"/>
                         <outlet property="verboseLabelsCheckbox" destination="pTP-wb-bab" id="Piq-xX-ADo"/>
                     </connections>
                 </viewController>
@@ -591,7 +460,42 @@ of Pi-hole LLC.</string>
                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </textFieldCell>
             </objects>
-            <point key="canvasLocation" x="649" y="-108"/>
+            <point key="canvasLocation" x="570.5" y="-108"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="ayz-je-3b6">
+            <objects>
+                <viewController storyboardIdentifier="piHoleDialog" id="JhG-OK-RWV" sceneMemberID="viewController">
+                    <view key="view" id="VTg-m3-cFh">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vRR-BU-YIk">
+                                <rect key="frame" x="361" y="13" width="75" height="32"/>
+                                <buttonCell key="cell" type="push" title="Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zIe-00-a3j">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vfb-vc-iXD">
+                                <rect key="frame" x="233" y="13" width="120" height="32"/>
+                                <buttonCell key="cell" type="push" title="Save &amp; Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5bc-6L-W4D">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="vRR-BU-YIk" secondAttribute="trailing" constant="20" id="V7C-dC-jRp"/>
+                            <constraint firstAttribute="bottom" secondItem="vRR-BU-YIk" secondAttribute="bottom" constant="20" id="fSr-NA-ENf"/>
+                            <constraint firstItem="vRR-BU-YIk" firstAttribute="leading" secondItem="vfb-vc-iXD" secondAttribute="trailing" constant="20" id="pQO-tj-9jb"/>
+                            <constraint firstAttribute="bottom" secondItem="vfb-vc-iXD" secondAttribute="bottom" constant="20" id="xfs-9P-xw9"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="IJx-K2-eHd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="546" y="268"/>
         </scene>
     </scenes>
     <resources>

--- a/PiBar/Preferences/Base.lproj/Preferences.storyboard
+++ b/PiBar/Preferences/Base.lproj/Preferences.storyboard
@@ -245,7 +245,7 @@
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="17" id="a6a-Xt-gEO"/>
                                                                                 </constraints>
-                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="80" id="kOl-RG-hD1">
+                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="80" id="kOl-RG-hD1">
                                                                                     <font key="font" metaFont="system"/>
                                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -314,6 +314,9 @@
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
+                                            <connections>
+                                                <action selector="editButtonAction:" target="GTm-9k-36S" id="aRk-6X-IPm"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -443,6 +446,7 @@ of Pi-hole LLC.</string>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="editButton" destination="UaV-nP-7Dw" id="MZb-jQ-rWV"/>
                         <outlet property="removeButton" destination="tFg-7b-Rry" id="Hnp-f3-vw3"/>
                         <outlet property="shortcutEnabledCheckbox" destination="xv5-Li-uDo" id="2X1-v2-Zg4"/>
                         <outlet property="showBlockedCheckbox" destination="MiM-8y-LcW" id="BLs-6A-5qO"/>
@@ -462,12 +466,12 @@ of Pi-hole LLC.</string>
             </objects>
             <point key="canvasLocation" x="570.5" y="-108"/>
         </scene>
-        <!--View Controller-->
+        <!--Pihole Settings View Controller-->
         <scene sceneID="ayz-je-3b6">
             <objects>
-                <viewController storyboardIdentifier="piHoleDialog" id="JhG-OK-RWV" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="piHoleDialog" id="JhG-OK-RWV" customClass="PiholeSettingsViewController" customModule="PiBar" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="VTg-m3-cFh">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="244"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vRR-BU-YIk">
@@ -476,22 +480,166 @@ of Pi-hole LLC.</string>
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <connections>
+                                    <action selector="dismissController:" target="JhG-OK-RWV" id="UzQ-Ie-Mel"/>
+                                </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vfb-vc-iXD">
                                 <rect key="frame" x="233" y="13" width="120" height="32"/>
-                                <buttonCell key="cell" type="push" title="Save &amp; Close" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5bc-6L-W4D">
+                                <buttonCell key="cell" type="push" title="Save &amp; Close" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5bc-6L-W4D">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <connections>
+                                    <action selector="saveAndCloseButtonAction:" target="JhG-OK-RWV" id="YFb-zY-uRe"/>
+                                </connections>
                             </button>
+                            <box title="Pi-hole Settings" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="3K7-bD-5VH">
+                                <rect key="frame" x="17" y="57" width="416" height="149"/>
+                                <view key="contentView" id="xIe-VM-MBv">
+                                    <rect key="frame" x="3" y="3" width="410" height="143"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DfX-5W-cje">
+                                            <rect key="frame" x="90" y="102" width="125" height="21"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="pi.hole" drawsBackground="YES" id="OnA-u0-rmY">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="i4e-zs-pkU">
+                                            <rect key="frame" x="257" y="102" width="48" height="21"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="48" id="rt7-vm-50T"/>
+                                            </constraints>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="right" placeholderString="80" drawsBackground="YES" id="LB1-Nk-dwo">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MAW-Ao-XAm">
+                                            <rect key="frame" x="18" y="105" width="66" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Hostname" id="gtZ-N9-HyG">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ut9-zN-gOe">
+                                            <rect key="frame" x="221" y="105" width="30" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Port" id="1id-2a-G2U">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ey9-va-KwP">
+                                            <rect key="frame" x="319" y="104" width="73" height="18"/>
+                                            <buttonCell key="cell" type="check" title="Use SSL" bezelStyle="regularSquare" imagePosition="left" inset="2" id="B8q-U5-9nB">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="useSSLCheckboxAction:" target="JhG-OK-RWV" id="h1g-Lw-zVD"/>
+                                            </connections>
+                                        </button>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gNv-Mk-yT2">
+                                            <rect key="frame" x="18" y="64" width="66" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="API Token" id="i0I-aw-SzO">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bHH-DP-Aad">
+                                            <rect key="frame" x="90" y="61" width="300" height="21"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="No password on your Pi-hole? Leave this blank." drawsBackground="YES" id="Dz6-14-hXD">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8yS-Xd-FIv">
+                                            <rect key="frame" x="257" y="13" width="139" height="32"/>
+                                            <buttonCell key="cell" type="push" title="Test Connection" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Jse-Qu-5I1">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="testConnectionButtonAction:" target="JhG-OK-RWV" id="YvV-zm-GeY"/>
+                                            </connections>
+                                        </button>
+                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3yj-eZ-X0Q">
+                                            <rect key="frame" x="18" y="23" width="231" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" id="qJD-6U-lOR">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="DfX-5W-cje" firstAttribute="leading" secondItem="MAW-Ao-XAm" secondAttribute="trailing" constant="8" id="1Ie-pR-YQm"/>
+                                        <constraint firstItem="ut9-zN-gOe" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="22" id="1M8-mX-jeT"/>
+                                        <constraint firstItem="8yS-Xd-FIv" firstAttribute="leading" secondItem="3yj-eZ-X0Q" secondAttribute="trailing" constant="16" id="44O-MJ-Xpd"/>
+                                        <constraint firstItem="DfX-5W-cje" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="20" id="8ck-rO-YT5"/>
+                                        <constraint firstItem="Ey9-va-KwP" firstAttribute="leading" secondItem="i4e-zs-pkU" secondAttribute="trailing" constant="16" id="Gfc-PQ-qLm"/>
+                                        <constraint firstItem="gNv-Mk-yT2" firstAttribute="top" secondItem="MAW-Ao-XAm" secondAttribute="bottom" constant="25" id="I6S-n6-VhR"/>
+                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="DfX-5W-cje" secondAttribute="leading" id="KgH-9Q-keL"/>
+                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="leading" secondItem="gNv-Mk-yT2" secondAttribute="trailing" constant="8" id="NHv-UB-iga"/>
+                                        <constraint firstAttribute="trailing" secondItem="Ey9-va-KwP" secondAttribute="trailing" constant="20" id="OCA-VW-hOb"/>
+                                        <constraint firstAttribute="trailing" secondItem="bHH-DP-Aad" secondAttribute="trailing" constant="20" id="OHo-Iw-mnv"/>
+                                        <constraint firstItem="8yS-Xd-FIv" firstAttribute="top" secondItem="bHH-DP-Aad" secondAttribute="bottom" constant="20" id="VCk-x3-DRG"/>
+                                        <constraint firstItem="i4e-zs-pkU" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="20" id="dk6-se-Tvm"/>
+                                        <constraint firstItem="Ey9-va-KwP" firstAttribute="centerY" secondItem="i4e-zs-pkU" secondAttribute="centerY" id="dn5-n2-9pM"/>
+                                        <constraint firstItem="3yj-eZ-X0Q" firstAttribute="top" secondItem="bHH-DP-Aad" secondAttribute="bottom" constant="22" id="fH4-EK-Oef"/>
+                                        <constraint firstItem="3yj-eZ-X0Q" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="jGA-OR-lsd"/>
+                                        <constraint firstItem="bHH-DP-Aad" firstAttribute="top" secondItem="DfX-5W-cje" secondAttribute="bottom" constant="20" id="l6z-e7-L62"/>
+                                        <constraint firstAttribute="trailing" secondItem="8yS-Xd-FIv" secondAttribute="trailing" constant="20" id="lhc-aT-bO8"/>
+                                        <constraint firstItem="MAW-Ao-XAm" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="oGQ-a5-dsw"/>
+                                        <constraint firstItem="gNv-Mk-yT2" firstAttribute="leading" secondItem="xIe-VM-MBv" secondAttribute="leading" constant="20" id="roe-fp-efQ"/>
+                                        <constraint firstItem="i4e-zs-pkU" firstAttribute="leading" secondItem="ut9-zN-gOe" secondAttribute="trailing" constant="8" id="vTD-sS-2r2"/>
+                                        <constraint firstAttribute="bottom" secondItem="8yS-Xd-FIv" secondAttribute="bottom" constant="20" id="wd5-G0-YLT"/>
+                                        <constraint firstItem="ut9-zN-gOe" firstAttribute="leading" secondItem="DfX-5W-cje" secondAttribute="trailing" constant="8" id="xXM-lj-2YQ"/>
+                                        <constraint firstItem="MAW-Ao-XAm" firstAttribute="top" secondItem="xIe-VM-MBv" secondAttribute="top" constant="22" id="yYD-b3-REr"/>
+                                    </constraints>
+                                </view>
+                            </box>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dnY-PR-vdq">
+                                <rect key="frame" x="18" y="212" width="414" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Pi-hole" id="hHW-QN-ohW">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="dnY-PR-vdq" firstAttribute="top" secondItem="VTg-m3-cFh" secondAttribute="top" constant="16" id="1Fs-r3-Cf6"/>
+                            <constraint firstItem="vRR-BU-YIk" firstAttribute="top" secondItem="3K7-bD-5VH" secondAttribute="bottom" constant="20" id="Iah-gQ-Le2"/>
                             <constraint firstAttribute="trailing" secondItem="vRR-BU-YIk" secondAttribute="trailing" constant="20" id="V7C-dC-jRp"/>
                             <constraint firstAttribute="bottom" secondItem="vRR-BU-YIk" secondAttribute="bottom" constant="20" id="fSr-NA-ENf"/>
+                            <constraint firstItem="dnY-PR-vdq" firstAttribute="leading" secondItem="VTg-m3-cFh" secondAttribute="leading" constant="20" id="he3-jT-AKX"/>
+                            <constraint firstItem="3K7-bD-5VH" firstAttribute="top" secondItem="dnY-PR-vdq" secondAttribute="bottom" constant="8" id="l0I-KA-YQ7"/>
+                            <constraint firstItem="vfb-vc-iXD" firstAttribute="leading" secondItem="VTg-m3-cFh" secondAttribute="leading" constant="239" id="liL-40-CAI"/>
+                            <constraint firstItem="3K7-bD-5VH" firstAttribute="leading" secondItem="VTg-m3-cFh" secondAttribute="leading" constant="20" id="mYx-X1-zTE"/>
                             <constraint firstItem="vRR-BU-YIk" firstAttribute="leading" secondItem="vfb-vc-iXD" secondAttribute="trailing" constant="20" id="pQO-tj-9jb"/>
+                            <constraint firstAttribute="trailing" secondItem="3K7-bD-5VH" secondAttribute="trailing" constant="20" id="r3R-bE-yJ7"/>
+                            <constraint firstAttribute="trailing" secondItem="dnY-PR-vdq" secondAttribute="trailing" constant="20" id="wWS-t6-y61"/>
                             <constraint firstAttribute="bottom" secondItem="vfb-vc-iXD" secondAttribute="bottom" constant="20" id="xfs-9P-xw9"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="apiTokenTextField" destination="bHH-DP-Aad" id="gBu-T5-UwO"/>
+                        <outlet property="closeButton" destination="vRR-BU-YIk" id="buO-2f-uD1"/>
+                        <outlet property="hostnameTextField" destination="DfX-5W-cje" id="KIl-2F-AeS"/>
+                        <outlet property="portTextField" destination="i4e-zs-pkU" id="crJ-yc-pNH"/>
+                        <outlet property="saveAndCloseButton" destination="vfb-vc-iXD" id="dB9-fJ-Qls"/>
+                        <outlet property="testConnectionButton" destination="8yS-Xd-FIv" id="3qZ-7N-jrE"/>
+                        <outlet property="useSSLCheckbox" destination="Ey9-va-KwP" id="gdT-ZG-lrd"/>
+                    </connections>
                 </viewController>
                 <customObject id="IJx-K2-eHd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PiBar/Preferences/PiholeSettingsViewController.swift
+++ b/PiBar/Preferences/PiholeSettingsViewController.swift
@@ -9,19 +9,23 @@
 import Cocoa
 
 protocol PiholeSettingsViewControllerDelegate: AnyObject {
-    func savePiholeConnection(_ connection: PiholeConnectionV2, at index: Int?)
+    func savePiholeConnection(_ connection: PiholeConnectionV2, at index: Int)
 }
 
 class PiholeSettingsViewController: NSViewController {
 
     var connection: PiholeConnectionV2?
     var currentIndex: Int = -1
+    weak var delegate: PiholeSettingsViewControllerDelegate?
+
+    var passwordProtected: Bool = true
 
     // MARK: - Outlets
     @IBOutlet weak var hostnameTextField: NSTextField!
     @IBOutlet weak var portTextField: NSTextField!
     @IBOutlet weak var useSSLCheckbox: NSButton!
     @IBOutlet weak var apiTokenTextField: NSTextField!
+    @IBOutlet weak var adminURLTextField: NSTextField!
 
     @IBOutlet weak var testConnectionButton: NSButton!
     @IBOutlet weak var testConnectionLabel: NSTextField!
@@ -29,7 +33,15 @@ class PiholeSettingsViewController: NSViewController {
     @IBOutlet weak var closeButton: NSButton!
 
     // MARK: - Actions
+    @IBAction func textFieldDidChangeAction(_ sender: NSTextField) {
+        updateAdminURLPlaceholder()
+        saveAndCloseButton.isEnabled = false
+    }
+
     @IBAction func useSSLCheckboxAction(_ sender: NSButton) {
+        sslFailSafe()
+        updateAdminURLPlaceholder()
+        saveAndCloseButton.isEnabled = false
     }
 
     @IBAction func testConnectionButtonAction(_ sender: NSButton) {
@@ -37,11 +49,29 @@ class PiholeSettingsViewController: NSViewController {
     }
 
     @IBAction func saveAndCloseButtonAction(_ sender: NSButton) {
+        var adminPanelURL = adminURLTextField.stringValue
+        if adminPanelURL.isEmpty {
+            adminPanelURL = PiholeConnectionV2.generateAdminPanelURL(
+                hostname: hostnameTextField.stringValue,
+                port: Int(portTextField.stringValue) ?? 80,
+                useSSL: apiTokenTextField.stringValue.isEmpty ? true : false)
+        }
+        delegate?.savePiholeConnection(PiholeConnectionV2(
+            hostname: hostnameTextField.stringValue,
+            port: Int(portTextField.stringValue) ?? 80,
+            useSSL: useSSLCheckbox.state == .on ? true : false,
+            token: apiTokenTextField.stringValue,
+            passwordProtected: passwordProtected,
+            adminPanelURL: adminPanelURL
+        ), at: currentIndex)
+        self.dismiss(self)
     }
 
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        adminURLTextField.toolTip = "Only fill this in if you have a custom Admin panel URL you'd like to use instead of the default shown here."
     }
 
     override func viewWillAppear() {
@@ -56,17 +86,45 @@ class PiholeSettingsViewController: NSViewController {
             portTextField.stringValue = "\(connection.port)"
             useSSLCheckbox.state = connection.useSSL ? .on : .off
             apiTokenTextField.stringValue = connection.token
+            adminURLTextField.stringValue = connection.adminPanelURL
         } else {
             hostnameTextField.stringValue = "pi.hole"
             portTextField.stringValue = "80"
             useSSLCheckbox.state = .off
             apiTokenTextField.stringValue = ""
+            adminURLTextField.stringValue = ""
+            adminURLTextField.placeholderString = PiholeConnectionV2.generateAdminPanelURL(
+                hostname: "pi.hole",
+                port: 80,
+                useSSL: false
+            )
         }
         testConnectionLabel.stringValue = ""
         saveAndCloseButton.isEnabled = false
     }
 
     // MARK: - Functions
+
+    fileprivate func sslFailSafe() {
+        let useSSL = useSSLCheckbox.state == .on ? true : false
+
+        var port = portTextField.stringValue
+        if useSSL, port == "80" {
+            port = "443"
+        } else if !useSSL, port == "443" {
+            port = "80"
+        }
+        portTextField.stringValue = port
+    }
+
+    private func updateAdminURLPlaceholder() {
+        let adminURLString = PiholeConnectionV2.generateAdminPanelURL(
+           hostname: hostnameTextField.stringValue,
+           port: Int(portTextField.stringValue) ?? 80,
+           useSSL: (useSSLCheckbox.state == .on ? true : false)
+       )
+       adminURLTextField.placeholderString = "\(adminURLString)"
+    }
 
     func testConnection() {
         Log.debug("Testing connection...")
@@ -78,7 +136,8 @@ class PiholeSettingsViewController: NSViewController {
             port: Int(portTextField.stringValue) ?? 80,
             useSSL: useSSLCheckbox.state == .on ? true : false,
             token: apiTokenTextField.stringValue,
-            passwordProtected: apiTokenTextField.stringValue.isEmpty ? true : false
+            passwordProtected: passwordProtected,
+            adminPanelURL: ""
         )
 
         let api = PiholeAPI(connection: connection)
@@ -88,6 +147,11 @@ class PiholeSettingsViewController: NSViewController {
             case .success:
                 self.testConnectionLabel.stringValue = "Success"
                 self.saveAndCloseButton.isEnabled = true
+                if self.apiTokenTextField.stringValue.isEmpty {
+                    self.passwordProtected = false
+                } else {
+                    self.passwordProtected = true
+                }
             case .failure:
                 self.testConnectionLabel.stringValue = "Unable to Connect"
                 self.saveAndCloseButton.isEnabled = false

--- a/PiBar/Preferences/PiholeSettingsViewController.swift
+++ b/PiBar/Preferences/PiholeSettingsViewController.swift
@@ -24,6 +24,7 @@ class PiholeSettingsViewController: NSViewController {
     @IBOutlet weak var apiTokenTextField: NSTextField!
 
     @IBOutlet weak var testConnectionButton: NSButton!
+    @IBOutlet weak var testConnectionLabel: NSTextField!
     @IBOutlet weak var saveAndCloseButton: NSButton!
     @IBOutlet weak var closeButton: NSButton!
 
@@ -32,6 +33,7 @@ class PiholeSettingsViewController: NSViewController {
     }
 
     @IBAction func testConnectionButtonAction(_ sender: NSButton) {
+        testConnection()
     }
 
     @IBAction func saveAndCloseButtonAction(_ sender: NSButton) {
@@ -59,6 +61,40 @@ class PiholeSettingsViewController: NSViewController {
             portTextField.stringValue = "80"
             useSSLCheckbox.state = .off
             apiTokenTextField.stringValue = ""
+        }
+        testConnectionLabel.stringValue = ""
+        saveAndCloseButton.isEnabled = false
+    }
+
+    // MARK: - Functions
+
+    func testConnection() {
+        Log.debug("Testing connection...")
+
+        testConnectionLabel.stringValue = "Testing..."
+
+        let connection = PiholeConnectionV2(
+            hostname: hostnameTextField.stringValue,
+            port: Int(portTextField.stringValue) ?? 80,
+            useSSL: useSSLCheckbox.state == .on ? true : false,
+            token: apiTokenTextField.stringValue,
+            passwordProtected: apiTokenTextField.stringValue.isEmpty ? true : false
+        )
+
+        let api = PiholeAPI(connection: connection)
+
+        api.testConnection { status in
+            switch status {
+            case .success:
+                self.testConnectionLabel.stringValue = "Success"
+                self.saveAndCloseButton.isEnabled = true
+            case .failure:
+                self.testConnectionLabel.stringValue = "Unable to Connect"
+                self.saveAndCloseButton.isEnabled = false
+            case .failureInvalidToken:
+                self.testConnectionLabel.stringValue = "Invalid API Token"
+                self.saveAndCloseButton.isEnabled = false
+            }
         }
     }
 }

--- a/PiBar/Preferences/PiholeSettingsViewController.swift
+++ b/PiBar/Preferences/PiholeSettingsViewController.swift
@@ -129,7 +129,7 @@ class PiholeSettingsViewController: NSViewController {
     func testConnection() {
         Log.debug("Testing connection...")
 
-        testConnectionLabel.stringValue = "Testing..."
+        testConnectionLabel.stringValue = "Testing... Please wait..."
 
         let connection = PiholeConnectionV2(
             hostname: hostnameTextField.stringValue,

--- a/PiBar/Preferences/PiholeSettingsViewController.swift
+++ b/PiBar/Preferences/PiholeSettingsViewController.swift
@@ -1,0 +1,64 @@
+//
+//  PiholeSettingsViewController.swift
+//  PiBar
+//
+//  Created by Brad Root on 5/25/20.
+//  Copyright © 2020 Brad Root. All rights reserved.
+//
+
+import Cocoa
+
+protocol PiholeSettingsViewControllerDelegate: AnyObject {
+    func savePiholeConnection(_ connection: PiholeConnectionV2, at index: Int?)
+}
+
+class PiholeSettingsViewController: NSViewController {
+
+    var connection: PiholeConnectionV2?
+    var currentIndex: Int = -1
+
+    // MARK: - Outlets
+    @IBOutlet weak var hostnameTextField: NSTextField!
+    @IBOutlet weak var portTextField: NSTextField!
+    @IBOutlet weak var useSSLCheckbox: NSButton!
+    @IBOutlet weak var apiTokenTextField: NSTextField!
+
+    @IBOutlet weak var testConnectionButton: NSButton!
+    @IBOutlet weak var saveAndCloseButton: NSButton!
+    @IBOutlet weak var closeButton: NSButton!
+
+    // MARK: - Actions
+    @IBAction func useSSLCheckboxAction(_ sender: NSButton) {
+    }
+
+    @IBAction func testConnectionButtonAction(_ sender: NSButton) {
+    }
+
+    @IBAction func saveAndCloseButtonAction(_ sender: NSButton) {
+    }
+
+    // MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        loadPiholeConnection()
+    }
+
+    func loadPiholeConnection() {
+        Log.debug("Loading Pi-hole at index \(currentIndex)")
+        if let connection = connection {
+            hostnameTextField.stringValue = connection.hostname
+            portTextField.stringValue = "\(connection.port)"
+            useSSLCheckbox.state = connection.useSSL ? .on : .off
+            apiTokenTextField.stringValue = connection.token
+        } else {
+            hostnameTextField.stringValue = "pi.hole"
+            portTextField.stringValue = "80"
+            useSSLCheckbox.state = .off
+            apiTokenTextField.stringValue = ""
+        }
+    }
+}

--- a/PiBar/Preferences/PreferencesViewController.swift
+++ b/PiBar/Preferences/PreferencesViewController.swift
@@ -23,14 +23,6 @@ class PreferencesViewController: NSViewController {
 
     @IBOutlet var tableView: NSTableView!
 
-    @IBOutlet var testLabel: NSTextField!
-    @IBOutlet var testButton: NSButton!
-
-    @IBOutlet var hostnameTextField: NSTextField!
-    @IBOutlet var portTextField: NSTextField!
-    @IBOutlet var tokenTextField: NSTextField!
-    @IBOutlet var useSSLCheckbox: NSButton!
-
     @IBOutlet var showBlockedCheckbox: NSButton!
     @IBOutlet var showQueriesCheckbox: NSButton!
     @IBOutlet var showPercentageCheckbox: NSButton!
@@ -41,18 +33,11 @@ class PreferencesViewController: NSViewController {
     @IBOutlet var shortcutEnabledCheckbox: NSButton!
 
     @IBOutlet var removeButton: NSButton!
-    @IBOutlet var saveButton: NSButton!
 
     // MARK: - Actions
 
     @IBAction func addButtonActiom(_: NSButton) {
-        var piholes = Preferences.standard.piholes
-        piholes.append(PiholeConnection(hostname: "pi-hole.local", port: 80, useSSL: false, token: ""))
-        Preferences.standard.set(piholes: piholes)
-        let newRowIndexSet = IndexSet(integer: piholes.count - 1)
-        tableView.insertRows(at: newRowIndexSet, withAnimation: .slideDown)
-        tableView.selectRowIndexes(newRowIndexSet, byExtendingSelection: false)
-        delegate?.updatedConnections()
+
     }
 
     @IBAction func removeButtonAction(_: NSButton) {
@@ -63,40 +48,8 @@ class PreferencesViewController: NSViewController {
         delegate?.updatedConnections()
     }
 
-    @IBAction func textFieldChangedAction(_: NSTextField) {
-        saveButton.isEnabled = false
-        saveButton.toolTip = "Test connection to save changes."
-        testLabel.stringValue = ""
-        sslFailSafe()
-    }
-
-    @IBAction func useSSLCheckboxAction(_: NSButton) {
-        sslFailSafe()
-    }
-
-    @IBAction func saveButtonAction(_: Any) {
-        let selectedIndex = tableView.selectedRow
-        var piholes = Preferences.standard.piholes
-
-        piholes[selectedIndex] = PiholeConnection(
-            hostname: hostnameTextField.stringValue,
-            port: Int(portTextField.stringValue) ?? 80,
-            useSSL: useSSLCheckbox.state == .on ? true : false,
-            token: tokenTextField.stringValue
-        )
-
-        Preferences.standard.set(piholes: piholes)
-        tableView.reloadData()
-        tableView.selectRowIndexes(IndexSet(integer: selectedIndex), byExtendingSelection: false)
-        delegate?.updatedConnections()
-    }
-
     @IBAction func checkboxAction(_: NSButtonCell) {
         saveSettings()
-    }
-
-    @IBAction func testButtonAction(_: NSButton) {
-        testConnection()
     }
 
     @IBAction func linkAction(_: NSButton) {
@@ -111,9 +64,6 @@ class PreferencesViewController: NSViewController {
 
         updateUI()
 
-        loadDataFromTable()
-
-        tokenTextField.toolTip = "Get your API token from Pi-hole: Settings -> API / Web Interface -> Show API token"
         shortcutEnabledCheckbox.toolTip = "This shortcut allows you to easily enable and disable your Pi-hole(s)"
     }
 
@@ -136,21 +86,7 @@ class PreferencesViewController: NSViewController {
 
     // MARK: - Functions
 
-    fileprivate func sslFailSafe() {
-        let useSSL = useSSLCheckbox.state == .on ? true : false
-
-        var port = portTextField.stringValue
-        if useSSL, port == "80" {
-            port = "443"
-        } else if !useSSL, port == "443" {
-            port = "80"
-        }
-        portTextField.stringValue = port
-    }
-
     func saveSettings() {
-        testLabel.stringValue = ""
-
         Preferences.standard.set(showBlocked: showBlockedCheckbox.state == .on ? true : false)
         Preferences.standard.set(showQueries: showQueriesCheckbox.state == .on ? true : false)
         Preferences.standard.set(showPercentage: showPercentageCheckbox.state == .on ? true : false)
@@ -167,34 +103,6 @@ class PreferencesViewController: NSViewController {
         delegate?.updatedPreferences()
 
         updateUI()
-    }
-
-    func testConnection() {
-        let connection = PiholeConnection(
-            hostname: hostnameTextField.stringValue,
-            port: Int(portTextField.stringValue) ?? 80,
-            useSSL: useSSLCheckbox.state == .on ? true : false,
-            token: tokenTextField.stringValue
-        )
-
-        let api = PiholeAPI(connection: connection)
-
-        api.testConnection { status in
-            switch status {
-            case .success:
-                self.testLabel.stringValue = "Success!"
-                self.saveButton.isEnabled = true
-            case .successNoToken:
-                self.testLabel.stringValue = "Success (No Admin)"
-                self.saveButton.isEnabled = true
-            case .failure:
-                self.testLabel.stringValue = "Failure (No Connection)"
-                self.saveButton.isEnabled = false
-            case .failureInvalidToken:
-                self.testLabel.stringValue = "Failure (Invalid Token)"
-                self.saveButton.isEnabled = false
-            }
-        }
     }
 }
 
@@ -226,47 +134,5 @@ extension PreferencesViewController: NSTableViewDelegate {
             return cell
         }
         return nil
-    }
-
-    fileprivate func loadDataFromTable() {
-        if tableView.selectedRow >= 0 {
-            let pihole = Preferences.standard.piholes[tableView.selectedRow]
-            hostnameTextField.stringValue = pihole.hostname
-            portTextField.stringValue = "\(pihole.port)"
-            tokenTextField.stringValue = pihole.token
-            useSSLCheckbox.state = pihole.useSSL ? .on : .off
-
-            hostnameTextField.isEnabled = true
-            portTextField.isEnabled = true
-            tokenTextField.isEnabled = true
-            useSSLCheckbox.isEnabled = true
-
-            removeButton.isEnabled = true
-            testButton.isEnabled = true
-            saveButton.isEnabled = false
-            saveButton.toolTip = "Test connection to save changes."
-            testLabel.stringValue = ""
-        } else {
-            hostnameTextField.stringValue = ""
-            portTextField.stringValue = ""
-            tokenTextField.stringValue = ""
-            useSSLCheckbox.state = .off
-
-            hostnameTextField.isEnabled = false
-            portTextField.isEnabled = false
-            tokenTextField.isEnabled = false
-            useSSLCheckbox.isEnabled = false
-
-            removeButton.isEnabled = false
-            testButton.isEnabled = false
-            saveButton.isEnabled = false
-            saveButton.toolTip = nil
-
-            testLabel.stringValue = ""
-        }
-    }
-
-    func tableViewSelectionDidChange(_: Notification) {
-        loadDataFromTable()
     }
 }


### PR DESCRIPTION
- Re-designs the preferences screen to have a separate panel slide down for editing / adding Pi-holes. This should de-clutter the UI as well as make it easier to fix some bugs surrounding the previous pi-hole creation functions
- Fetching methods in `PiholeAPI.swift` have been re-done to support timeouts
- Pi-holes that do not need API tokens are properly supported
  - "Stats only" mode has been removed as part of this change, which I think is okay because I figure there are very few people who are using PiBar to NOT control their Pi-holes
- Pi-holes saved in PiBar v1.0 are automatically migrated to a new struct format on first launch
- New struct format supports flagging a connection as not having password protection, as well as support for customizing the admin panel URL if necessary