### PR TITLE
Fixes for 1.1 Beta

### DIFF
--- a/PiBar/Data Sources/PiholeAPI.swift
+++ b/PiBar/Data Sources/PiholeAPI.swift
@@ -71,7 +71,7 @@ class PiholeAPI: NSObject {
         let session = URLSession(configuration: .default)
         let dataTask = session.dataTask(with: urlRequest) { data, response, error in
             if error != nil {
-                completion(nil)
+                return completion(nil)
             }
             if let response = response as? HTTPURLResponse {
                 if 200 ..< 300 ~= response.statusCode {

--- a/PiBar/Info.plist
+++ b/PiBar/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>146</string>
+	<string>147</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/PiBar/Info.plist
+++ b/PiBar/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>134</string>
+	<string>146</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/PiBar/Manager/Operations/UpdatePiholeOperation.swift
+++ b/PiBar/Manager/Operations/UpdatePiholeOperation.swift
@@ -18,7 +18,7 @@ final class UpdatePiholeOperation: AsyncOperation {
     override func main() {
         Log.debug("Updating Pi-hole: \(pihole.identifier)")
         pihole.api.fetchSummary { summary in
-            Log.debug("Updating Pi-hole: \(self.pihole.identifier) - Received Summary")
+            Log.debug("Received Summary for \(self.pihole.identifier)")
             var enabled: Bool? = true
             var online = true
             var canBeManaged: Bool = false


### PR DESCRIPTION
Noticed that PiBar 1.1 beta was crashing locally. The cause wasn't particularly clear so I'm doing a couple things that could fix potential crash sources...

1. Instead of view controllers accessing the `PiholeNetworkOverview` directly from the manager, when it is updated it is sent to the delegate. This ensures that fewer 'things' are trying to access the struct at the same time.
2. Trying to make sure all UI updates happen async, previously the admin menu items weren't updating asynchronously.
3. Making sure all fetches from a dictionary are wrapped up in a guard statement.

So far it seems like this has solved the crashing issue.