### PR TITLE
Only One Operation at a Time, Fellas

### DIFF
--- a/PiBar/Info.plist
+++ b/PiBar/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>147</string>
+	<string>177</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
- ensures only one operation can run at a time, avoiding conditions where multiple operations could try to write to the same dictionary at the same time. I think this was causing a crash.
- also reduces closure nesting by using `for` instead of `.forEach {}`