### PR TITLE
Pihole web v5.18 requires auth on all API endpoints now

### DIFF
--- a/PiBar/Data Sources/PiholeAPI.swift
+++ b/PiBar/Data Sources/PiholeAPI.swift
@@ -22,13 +22,13 @@ class PiholeAPI: NSObject {
     private let timeout: Int = 2
 
     private enum Endpoints {
-        static let summary = PiholeAPIEndpoint(queryParameter: "summaryRaw", authorizationRequired: false)
-        static let overTimeData10mins = PiholeAPIEndpoint(queryParameter: "overTimeData10mins", authorizationRequired: false)
+        static let summary = PiholeAPIEndpoint(queryParameter: "summaryRaw", authorizationRequired: true)
+        static let overTimeData10mins = PiholeAPIEndpoint(queryParameter: "overTimeData10mins", authorizationRequired: true)
         static let topItems = PiholeAPIEndpoint(queryParameter: "topItems", authorizationRequired: true)
         static let topClients = PiholeAPIEndpoint(queryParameter: "topClients", authorizationRequired: true)
         static let enable = PiholeAPIEndpoint(queryParameter: "enable", authorizationRequired: true)
         static let disable = PiholeAPIEndpoint(queryParameter: "disable", authorizationRequired: true)
-        static let recentBlocked = PiholeAPIEndpoint(queryParameter: "recentBlocked", authorizationRequired: false)
+        static let recentBlocked = PiholeAPIEndpoint(queryParameter: "recentBlocked", authorizationRequired: true)
     }
 
     override init() {


### PR DESCRIPTION
Pihole web v5.18 requires auth on all API endpoints now except for version and type. I am not a Swift dev, don't know how to compile and test these changes.

PR that caused this change - https://github.com/pi-hole/AdminLTE/pull/2411
Pihole release - https://github.com/pi-hole/AdminLTE/releases/v5.18

Since upgrading to the Pihole web v5.18, PiBar no longer works. Only the test connection function returns true.
<img width="181" alt="Screenshot 2022-12-23 at 10 57 31 AM" src="https://user-images.githubusercontent.com/9219376/209394790-c47787e6-ae08-4c74-88a3-afcfbd3bf72b.png">
<img width="436" alt="Screenshot 2022-12-23 at 10 57 48 AM" src="https://user-images.githubusercontent.com/9219376/209394797-fe8ee5c3-a170-41bd-bf83-8dca03e7cca4.png">
